### PR TITLE
Go 1.6

### DIFF
--- a/cpp/capi.cpp
+++ b/cpp/capi.cpp
@@ -45,16 +45,21 @@ void panicf(const char *format, ...)
     hookPanic(local_strdup(ba.constData()));
 }
 
-void newGuiApplication()
+void newGuiApplication(int argc, char **argv)
 {
-    static char empty[1] = {0};
-    static char *argv[] = {empty, 0};
-    static int argc = 1;
-    new QApplication(argc, argv);
+    // if empty is {0} then WM_CLASS is never set due to some crappy logic
+    // in QXcbIntegration::wmClass()
+    static char empty[4] = {'q', 'm', 'l', 0};
+    static char *argv_[] = {empty, 0};
+    static int argc_ = 1;
+    // and, if we use argc and argv, it crashes about
+    // 3/4 of the time with std::bad_alloc()
+    new QApplication(argc_, argv_);
 
     // The event loop should never die.
     qApp->setQuitOnLastWindowClosed(false);
 }
+
 
 void applicationExec()
 {

--- a/cpp/capi.cpp
+++ b/cpp/capi.cpp
@@ -768,6 +768,9 @@ void unpackDataValue(DataValue *value, QVariant_ *var)
     case DTObject:
         qvar->setValue(*(QObject**)(value->data));
         break;
+    case DTNil:
+        *qvar = QVariant(QMetaType::VoidStar, (void *)0);
+        break;
     case DTInvalid:
         *qvar = QVariant(QMetaType::VoidStar, (void *)0);
         break;
@@ -825,6 +828,8 @@ void packDataValue(const QVariant_ *var, DataValue *value)
     case QMetaType::VoidStar:
         value->dataType = DTUintptr;
         *(uintptr_t*)(value->data) = (uintptr_t)qvar->value<void *>();
+        if (*(uintptr_t*)(value->data) == 0)
+          value->dataType = DTNil;
         break;
     case QMetaType::Double:
         value->dataType = DTFloat64;

--- a/cpp/capi.cpp
+++ b/cpp/capi.cpp
@@ -233,8 +233,8 @@ void guiappSetWindowIcon(const char *path, int pathLen)
 QQmlComponent_ *newComponent(QQmlEngine_ *engine, QObject_ *parent)
 {
     QQmlEngine *qengine = reinterpret_cast<QQmlEngine *>(engine);
-    //QObject *qparent = reinterpret_cast<QObject *>(parent);
-    QQmlComponent *qcomponent = new QQmlComponent(qengine);
+    QObject *qparent = reinterpret_cast<QObject *>(parent);
+    QQmlComponent *qcomponent = new QQmlComponent(qengine, qparent);
     // Qt 5.2.0 returns NULL on qmlEngine(qcomponent) without this.
     QQmlEngine::setContextForObject(qcomponent, qengine->rootContext());
     return qcomponent;

--- a/cpp/capi.h
+++ b/cpp/capi.h
@@ -108,7 +108,7 @@ typedef struct {
 } LogMessage;
 
 
-void newGuiApplication();
+void newGuiApplication(int argc, char **argv);
 void applicationExec();
 void applicationExit();
 void applicationFlushAll();

--- a/cpp/capi.h
+++ b/cpp/capi.h
@@ -29,7 +29,7 @@ typedef void QMessageLogContext_;
 typedef void QImage_;
 typedef void QPainter_;
 typedef void GoValue_;
-typedef void GoAddr;
+typedef size_t GoValueRef;
 typedef void GoTypeSpec_;
 
 typedef char error;
@@ -159,9 +159,9 @@ QQmlContext_ *objectContext(QObject_ *object);
 int objectIsComponent(QObject_ *object);
 int objectIsWindow(QObject_ *object);
 int objectIsView(QObject_ *object);
-error *objectConnect(QObject_ *object, const char *signal, int signalLen, QQmlEngine_ *engine, void *func, int argsLen);
+error *objectConnect(QObject_ *object, const char *signal, int signalLen, QQmlEngine_ *engine, GoValueRef func, int argsLen);
 error *objectDisconnect(QObject_ *object);
-error *objectGoAddr(QObject_ *object, GoAddr **addr);
+error *objectGoAddr(QObject_ *object, GoValueRef *addr);
 
 QQmlComponent_ *newComponent(QQmlEngine_ *engine, QObject_ *parent);
 void componentLoadURL(QQmlComponent_ *component, const char *url, int urlLen);
@@ -186,7 +186,7 @@ const unsigned char *imageConstBits(QImage_ *image);
 QString_ *newString(const char *data, int len);
 void delString(QString_ *s);
 
-GoValue_ *newGoValue(GoAddr *addr, GoTypeInfo *typeInfo, QObject_ *parent);
+GoValue_ *newGoValue(GoValueRef valueref, GoTypeInfo *typeInfo, QObject_ *parent);
 void goValueActivate(GoValue_ *value, GoTypeInfo *typeInfo, int addrOffset);
 
 void packDataValue(const QVariant_ *var, DataValue *result);
@@ -194,7 +194,7 @@ void unpackDataValue(DataValue *value, QVariant_ *result);
 
 QVariantList_ *newVariantList(DataValue *list, int len);
 
-QQmlListProperty_ *newListProperty(GoAddr *addr, intptr_t reflectIndex, intptr_t setIndex);
+QQmlListProperty_ *newListProperty(GoValueRef valueref, intptr_t reflectIndex, intptr_t setIndex);
 
 int registerType(char *location, int major, int minor, char *name, GoTypeInfo *typeInfo, GoTypeSpec_ *spec);
 int registerSingleton(char *location, int major, int minor, char *name, GoTypeInfo *typeInfo, GoTypeSpec_ *spec);
@@ -203,21 +203,21 @@ void installLogHandler();
 
 void hookIdleTimer();
 void hookLogHandler(LogMessage *message);
-void hookGoValueReadField(QQmlEngine_ *engine, GoAddr *addr, int memberIndex, int getIndex, int setIndex, DataValue *result);
-void hookGoValueWriteField(QQmlEngine_ *engine, GoAddr *addr, int memberIndex, int setIndex, DataValue *assign);
-void hookGoValueCallMethod(QQmlEngine_ *engine, GoAddr *addr, int memberIndex, DataValue *result);
-void hookGoValueDestroyed(QQmlEngine_ *engine, GoAddr *addr);
-void hookGoValuePaint(QQmlEngine_ *engine, GoAddr *addr, intptr_t reflextIndex, QPainter_* painter);
+void hookGoValueReadField(QQmlEngine_ *engine, GoValueRef valueref, int memberIndex, int getIndex, int setIndex, DataValue *result);
+void hookGoValueWriteField(QQmlEngine_ *engine, GoValueRef valueref, int memberIndex, int setIndex, DataValue *assign);
+void hookGoValueCallMethod(QQmlEngine_ *engine, GoValueRef valueref, int memberIndex, DataValue *result);
+void hookGoValueDestroyed(QQmlEngine_ *engine, GoValueRef valueref);
+void hookGoValuePaint(QQmlEngine_ *engine, GoValueRef valueref, intptr_t reflextIndex, QPainter_* painter);
 QImage_ *hookRequestImage(void *imageFunc, char *id, int idLen, int width, int height);
-GoAddr *hookGoValueTypeNew(GoValue_ *value, GoTypeSpec_ *spec);
+GoValueRef hookGoValueTypeNew(GoValue_ *value, GoTypeSpec_ *spec);
 void hookWindowHidden(QObject_ *addr);
-void hookSignalCall(QQmlEngine_ *engine, void *func, DataValue *params);
-void hookSignalDisconnect(void *func);
+void hookSignalCall(QQmlEngine_ *engine, GoValueRef func, DataValue *params);
+void hookSignalDisconnect(GoValueRef func);
 void hookPanic(char *message);
-int hookListPropertyCount(GoAddr *addr, intptr_t reflectIndex, intptr_t setIndex);
-QObject_ *hookListPropertyAt(GoAddr *addr, intptr_t reflectIndex, intptr_t setIndex, int i);
-void hookListPropertyAppend(GoAddr *addr, intptr_t reflectIndex, intptr_t setIndex, QObject_ *obj);
-void hookListPropertyClear(GoAddr *addr, intptr_t reflectIndex, intptr_t setIndex);
+int hookListPropertyCount(GoValueRef valueref, intptr_t reflectIndex, intptr_t setIndex);
+QObject_ *hookListPropertyAt(GoValueRef valueref, intptr_t reflectIndex, intptr_t setIndex, int i);
+void hookListPropertyAppend(GoValueRef valueref, intptr_t reflectIndex, intptr_t setIndex, QObject_ *obj);
+void hookListPropertyClear(GoValueRef valueref, intptr_t reflectIndex, intptr_t setIndex);
 
 void registerResourceData(int version, char *tree, char *name, char *data);
 void unregisterResourceData(int version, char *tree, char *name, char *data);

--- a/cpp/capi.h
+++ b/cpp/capi.h
@@ -39,6 +39,7 @@ void panicf(const char *format, ...);
 typedef enum {
     DTUnknown = 0, // Has an unsupported type.
     DTInvalid = 1, // Does not exist or similar.
+    DTNil     = 2,
 
     DTString  = 10,
     DTBool    = 11,

--- a/cpp/connector.h
+++ b/cpp/connector.h
@@ -5,13 +5,15 @@
 
 #include <stdint.h>
 
+typedef size_t GoValueRef;
+
 class Connector : public QObject
 {
     Q_OBJECT
 
     public:
 
-    Connector(QObject *sender, QMetaMethod method, QQmlEngine *engine, void *func, int argsLen)
+    Connector(QObject *sender, QMetaMethod method, QQmlEngine *engine, GoValueRef func, int argsLen)
         : QObject(sender), engine(engine), method(method), func(func), argsLen(argsLen) {};
 
     virtual ~Connector();
@@ -27,7 +29,7 @@ class Connector : public QObject
 
     QQmlEngine *engine;
     QMetaMethod method;
-    void *func;
+    GoValueRef func;
     int argsLen;
 };
 

--- a/cpp/goitemmodel.cpp
+++ b/cpp/goitemmodel.cpp
@@ -1,8 +1,8 @@
 
 #include "goitemmodel.h"
 
-GoItemModel::GoItemModel(QObject* parent, GoAddr* addr)
-	: QAbstractItemModel(parent), addr(addr) {
+GoItemModel::GoItemModel(QObject* parent, GoValueRef valueref)
+	: QAbstractItemModel(parent), valueref(valueref) {
 
 }
 
@@ -18,13 +18,13 @@ QModelIndex miCastFrom(QModelIndex_ *index) {
 
 // Required functions
 int GoItemModel::columnCount(const QModelIndex &parent) const {
-	return implColumnCount(addr, miCastTo(parent));
+	return implColumnCount(valueref, miCastTo(parent));
 }
 
 QVariant GoItemModel::data(const QModelIndex &index, int role) const {
 	DataValue value;
 
-	implData(addr, miCastTo(index), role, &value);
+	implData(valueref, miCastTo(index), role, &value);
 
   QVariant var;
   unpackDataValue(&value, &var);
@@ -33,27 +33,27 @@ QVariant GoItemModel::data(const QModelIndex &index, int role) const {
 }
 
 QModelIndex GoItemModel::index(int row, int column, const QModelIndex &parent) const {
-	return miCastFrom(implIndex(addr, row, column, miCastTo(parent)));
+	return miCastFrom(implIndex(valueref, row, column, miCastTo(parent)));
 }
 
 QModelIndex GoItemModel::parent(const QModelIndex &index) const {
-	return miCastFrom(implParent(addr, miCastTo(index)));
+	return miCastFrom(implParent(valueref, miCastTo(index)));
 }
 
 int GoItemModel::rowCount(const QModelIndex &parent) const {
-	return implRowCount(addr, miCastTo(parent));
+	return implRowCount(valueref, miCastTo(parent));
 }
 
 
 // Required for editing
 Qt::ItemFlags GoItemModel::flags(const QModelIndex &index) const {
-	return (Qt::ItemFlags)implFlags(addr, miCastTo(index));
+	return (Qt::ItemFlags)implFlags(valueref, miCastTo(index));
 }
 
 bool GoItemModel::setData(const QModelIndex &index, const QVariant &value, int role) {
 	DataValue *dv = (DataValue *) malloc(sizeof(DataValue));
     packDataValue(&value, dv);
-	return implSetData(addr, miCastTo(index), dv, role);
+	return implSetData(valueref, miCastTo(index), dv, role);
 }
 
 // Internal Protected functions

--- a/cpp/goitemmodel.h
+++ b/cpp/goitemmodel.h
@@ -15,7 +15,7 @@ class GoItemModel : public QAbstractItemModel
   Q_OBJECT
 public:
  	// QAbstractItemModel(QObject *parent = Q_NULLPTR)
- 	GoItemModel(QObject *parent, GoAddr *impl);
+ 	GoItemModel(QObject *parent, GoValueRef impl);
 	// virtual 	~QAbstractItemModel()
 
 	// Required functions
@@ -75,7 +75,7 @@ public:
 	// virtual Qt::DropActions 	supportedDropActions() const
 
 // private:
-    GoAddr *addr;
+    GoValueRef valueref;
 };
 
 #endif // GOITEMMODEL_H

--- a/cpp/goitemmodel_api.cpp
+++ b/cpp/goitemmodel_api.cpp
@@ -5,7 +5,7 @@
 #include <QAbstractItemModel>
 
 
-QItemModel_* newGoItemModel(QObject_* parent, GoAddr* impl) {
+QItemModel_* newGoItemModel(QObject_* parent, GoValueRef impl) {
 	return reinterpret_cast<QItemModel_*>(new GoItemModel(reinterpret_cast<QObject*>(parent), impl));
 }
 

--- a/cpp/goitemmodel_api.h
+++ b/cpp/goitemmodel_api.h
@@ -18,7 +18,7 @@ typedef void QVariant_;
 extern "C" {
 #endif
 
-QItemModel_* newGoItemModel(QObject_*, GoAddr*);
+QItemModel_* newGoItemModel(QObject_*, GoValueRef);
 void deleteGoItemModel(QItemModel_*);
 
 QModelIndex_ *modelIndexChild(QModelIndex_ *mi, int row, int col);

--- a/cpp/goitemmodel_impl.h
+++ b/cpp/goitemmodel_impl.h
@@ -16,19 +16,19 @@ typedef void QVariant_;
 extern "C" {
 #endif
 
-// QItemModel_* newGoItemModel(QObject_*, GoAddr*);
+// QItemModel_* newGoItemModel(QObject_*, GoValueRef);
 // void deleteGoItemModel(QItemModel_*);
 
 // Required functions
-int 			implColumnCount(GoAddr *impl, QModelIndex_ *parent);
-void      implData(GoAddr *impl, QModelIndex_ *index, int role, DataValue *ret);
-QModelIndex_ 	*implIndex(GoAddr *impl, int row, int column, QModelIndex_ *parent);
-QModelIndex_ 	*implParent(GoAddr *impl, QModelIndex_ *index);
-int 			implRowCount(GoAddr *impl, QModelIndex_ *parent);
+int 			implColumnCount(GoValueRef impl, QModelIndex_ *parent);
+void      implData(GoValueRef impl, QModelIndex_ *index, int role, DataValue *ret);
+QModelIndex_ 	*implIndex(GoValueRef impl, int row, int column, QModelIndex_ *parent);
+QModelIndex_ 	*implParent(GoValueRef impl, QModelIndex_ *index);
+int 			implRowCount(GoValueRef impl, QModelIndex_ *parent);
 
 // Required for editing
-int 			implFlags(GoAddr *impl, QModelIndex_ *index);
-bool 			implSetData(GoAddr *impl, QModelIndex_ *index, DataValue *value, int role);
+int 			implFlags(GoValueRef impl, QModelIndex_ *index);
+bool 			implSetData(GoValueRef impl, QModelIndex_ *index, DataValue *value, int role);
 
 
 // virtual QModelIndex 	buddy(const QModelIndex &index) const

--- a/cpp/govalue.cpp
+++ b/cpp/govalue.cpp
@@ -13,7 +13,7 @@
 class GoValueMetaObject : public QAbstractDynamicMetaObject
 {
 public:
-    GoValueMetaObject(QObject* value, GoAddr *addr, GoTypeInfo *typeInfo);
+    GoValueMetaObject(QObject* value, GoValueRef valueref, GoTypeInfo *typeInfo);
 
     void activatePropIndex(int propIndex);
 
@@ -22,12 +22,12 @@ protected:
 
 private:
     QObject *value;
-    GoAddr *addr;
+    GoValueRef valueref;
     GoTypeInfo *typeInfo;
 };
 
-GoValueMetaObject::GoValueMetaObject(QObject *value, GoAddr *addr, GoTypeInfo *typeInfo)
-    : value(value), addr(addr), typeInfo(typeInfo)
+GoValueMetaObject::GoValueMetaObject(QObject *value, GoValueRef valueref, GoTypeInfo *typeInfo)
+    : value(value), valueref(valueref), typeInfo(typeInfo)
 {
     //d->parent = static_cast<QAbstractDynamicMetaObject *>(priv->metaObject);
     *static_cast<QMetaObject *>(this) = *metaObjectFor(typeInfo);
@@ -53,7 +53,7 @@ int GoValueMetaObject::metaCall(QMetaObject::Call c, int idx, void **a)
                 if (memberInfo->metaIndex == idx) {
                     if (c == QMetaObject::ReadProperty) {
                         DataValue result;
-                        hookGoValueReadField(qmlEngine(value), addr, memberInfo->reflectIndex, memberInfo->reflectGetIndex, memberInfo->reflectSetIndex, &result);
+                        hookGoValueReadField(qmlEngine(value), valueref, memberInfo->reflectIndex, memberInfo->reflectGetIndex, memberInfo->reflectSetIndex, &result);
                         if (memberInfo->memberType == DTListProperty) {
                             if (result.dataType != DTListProperty) {
                                 panicf("reading DTListProperty field returned non-DTListProperty result");
@@ -71,7 +71,7 @@ int GoValueMetaObject::metaCall(QMetaObject::Call c, int idx, void **a)
                         DataValue assign;
                         QVariant *in = reinterpret_cast<QVariant *>(a[0]);
                         packDataValue(in, &assign);
-                        hookGoValueWriteField(qmlEngine(value), addr, memberInfo->reflectIndex, memberInfo->reflectSetIndex, &assign);
+                        hookGoValueWriteField(qmlEngine(value), valueref, memberInfo->reflectIndex, memberInfo->reflectSetIndex, &assign);
                         activate(value, methodOffset() + (idx - propOffset), 0);
                     }
                     return -1;
@@ -95,7 +95,7 @@ int GoValueMetaObject::metaCall(QMetaObject::Call c, int idx, void **a)
                     for (int i = 1; i < memberInfo->numIn+1; i++) {
                         packDataValue(reinterpret_cast<QVariant *>(a[i]), &args[i]);
                     }
-                    hookGoValueCallMethod(qmlEngine(value), addr, memberInfo->reflectIndex, args);
+                    hookGoValueCallMethod(qmlEngine(value), valueref, memberInfo->reflectIndex, args);
                     if (memberInfo->numOut > 0) {
                         unpackDataValue(&args[0], reinterpret_cast<QVariant *>(a[0]));
                     }
@@ -121,16 +121,16 @@ void GoValueMetaObject::activatePropIndex(int propIndex)
     activate(value, methodOffset() + relativeIndex, 0);
 }
 
-GoValue::GoValue(GoAddr *addr, GoTypeInfo *typeInfo, QObject *parent)
-    : addr(addr), typeInfo(typeInfo)
+GoValue::GoValue(GoValueRef valueref, GoTypeInfo *typeInfo, QObject *parent)
+    : valueref(valueref), typeInfo(typeInfo)
 {
-    valueMeta = new GoValueMetaObject(this, addr, typeInfo);
+    valueMeta = new GoValueMetaObject(this, valueref, typeInfo);
     setParent(parent);
 }
 
 GoValue::~GoValue()
 {
-    hookGoValueDestroyed(qmlEngine(this), addr);
+    hookGoValueDestroyed(qmlEngine(this), valueref);
 }
 
 void GoValue::activate(int propIndex)
@@ -138,10 +138,10 @@ void GoValue::activate(int propIndex)
     valueMeta->activatePropIndex(propIndex);
 }
 
-GoPaintedValue::GoPaintedValue(GoAddr *addr, GoTypeInfo *typeInfo, QObject *parent)
-    : addr(addr), typeInfo(typeInfo)
+GoPaintedValue::GoPaintedValue(GoValueRef valueref, GoTypeInfo *typeInfo, QObject *parent)
+    : valueref(valueref), typeInfo(typeInfo)
 {
-    valueMeta = new GoValueMetaObject(this, addr, typeInfo);
+    valueMeta = new GoValueMetaObject(this, valueref, typeInfo);
     setParent(parent);
 
     QQuickItem::setFlag(QQuickItem::ItemHasContents, true);
@@ -150,7 +150,7 @@ GoPaintedValue::GoPaintedValue(GoAddr *addr, GoTypeInfo *typeInfo, QObject *pare
 
 GoPaintedValue::~GoPaintedValue()
 {
-    hookGoValueDestroyed(qmlEngine(this), addr);
+    hookGoValueDestroyed(qmlEngine(this), valueref);
 }
 
 void GoPaintedValue::activate(int propIndex)
@@ -161,7 +161,7 @@ void GoPaintedValue::activate(int propIndex)
 void GoPaintedValue::paint(QPainter *painter)
 {
     painter->beginNativePainting();
-    hookGoValuePaint(qmlEngine(this), addr, typeInfo->paint->reflectIndex, painter);
+    hookGoValuePaint(qmlEngine(this), valueref, typeInfo->paint->reflectIndex, painter);
     painter->endNativePainting();
 }
 

--- a/cpp/govalue.h
+++ b/cpp/govalue.h
@@ -20,10 +20,10 @@ class GoValue : public QObject
     Q_OBJECT
 
 public:
-    GoAddr *addr;
+    GoValueRef valueref;
     GoTypeInfo *typeInfo;
 
-    GoValue(GoAddr *addr, GoTypeInfo *typeInfo, QObject *parent);
+    GoValue(GoValueRef valueref, GoTypeInfo *typeInfo, QObject *parent);
     virtual ~GoValue();
 
     void activate(int propIndex);
@@ -37,10 +37,10 @@ class GoPaintedValue : public QQuickPaintedItem
     Q_OBJECT
 
 public:
-    GoAddr *addr;
+    GoValueRef valueref;
     GoTypeInfo *typeInfo;
 
-    GoPaintedValue(GoAddr *addr, GoTypeInfo *typeInfo, QObject *parent);
+    GoPaintedValue(GoValueRef valueref, GoTypeInfo *typeInfo, QObject *parent);
     virtual ~GoPaintedValue();
 
     void activate(int propIndex);

--- a/cpp/qmodelindex.cpp
+++ b/cpp/qmodelindex.cpp
@@ -3,7 +3,7 @@
 #include "util.cpp"
 
 
-QModelIndex_* newGoModelIndex(QObject_* parent, GoAddr* impl) {
+QModelIndex_* newGoModelIndex(QObject_* parent, GoValueRef impl) {
 	return reinterpret_cast<QModelIndex_*>(new GoModelIndex(reinterpret_cast<QObject*>(parent), impl));
 }
 

--- a/cpp/qmodelindex.h
+++ b/cpp/qmodelindex.h
@@ -12,7 +12,7 @@ typedef void QModelIndex_;
 extern "C" {
 #endif
 
-QItemModel_* newGoItemModel(QObject_*, GoAddr*);
+QItemModel_* newGoItemModel(QObject_*, GoValueRef);
 void deleteGoItemModel(QItemModel_*);
 
 

--- a/datatype.go
+++ b/datatype.go
@@ -163,8 +163,8 @@ func unpackDataValue(dvalue *C.DataValue, engine *Engine) interface{} {
 	case C.DTGoAddr:
 		// ObjectByName also does this fold conversion, to have access
 		// to the cvalue. Perhaps the fold should be returned.
-		fold := (*(**valueFold)(datap))
-		ensureEngine(engine.addr, unsafe.Pointer(fold))
+		foldref := (*(*C.GoValueRef)(datap))
+		fold := ensureEngine(engine.addr, foldref)
 		return fold.gvalue
 	case C.DTInvalid:
 		return nil

--- a/datatype.go
+++ b/datatype.go
@@ -67,7 +67,7 @@ func init() {
 func packDataValue(value interface{}, dvalue *C.DataValue, engine *Engine, owner valueOwner) {
 	datap := unsafe.Pointer(&dvalue.data)
 	if value == nil {
-		dvalue.dataType = C.DTInvalid
+		dvalue.dataType = C.DTNil
 		return
 	}
 	switch value := value.(type) {
@@ -134,6 +134,8 @@ func unpackDataValue(dvalue *C.DataValue, engine *Engine) interface{} {
 	datap := unsafe.Pointer(&dvalue.data)
 	switch dvalue.dataType {
 	case C.DTUnknown:
+		return nil
+	case C.DTNil:
 		return nil
 	case C.DTString:
 		s := C.GoStringN(*(**C.char)(datap), dvalue.len)

--- a/datatype.go
+++ b/datatype.go
@@ -23,7 +23,7 @@ var (
 
 	ptrSize = C.size_t(unsafe.Sizeof(uintptr(0)))
 
-	nilPtr     = unsafe.Pointer(uintptr(0))
+	nilPtr     = unsafe.Pointer(nil)
 	nilCharPtr = (*C.char)(nilPtr)
 
 	typeString     = reflect.TypeOf("")

--- a/goitemmodel.go
+++ b/goitemmodel.go
@@ -63,7 +63,10 @@ func NewItemModel(engine *Engine, parent Object, impl ItemModelImpl) (ItemModel,
 	var imptr unsafe.Pointer
 
 	RunMain(func() {
-		imptr = C.newGoItemModel(parentPtr, unsafe.Pointer(im))
+		fold := &valueFold{
+			gvalue: im,
+		}
+		imptr = C.newGoItemModel(parentPtr, getFoldRef(fold))
 	})
 
 	im.common = CommonOf(imptr, engine)
@@ -191,16 +194,16 @@ func (qim *goItemModel) DataChanged(topLeft ModelIndex, bottomRight ModelIndex) 
 
 // Required functions
 //export implColumnCount
-func implColumnCount(qim uintptr, parent uintptr) int {
-	im := (*goItemModel)(unsafe.Pointer(qim))
+func implColumnCount(qim C.GoValueRef, parent uintptr) int {
+	im := foldFromRef(qim).gvalue.(*goItemModel)
 	parentMi := mkModelIndex(parent, im.common.engine)
 
 	return im.impl.ColumnCount(parentMi)
 }
 
 //export implData
-func implData(qim uintptr, index uintptr, role int, ret *C.DataValue) {
-	im := (*goItemModel)(unsafe.Pointer(qim))
+func implData(qim C.GoValueRef, index uintptr, role int, ret *C.DataValue) {
+	im := foldFromRef(qim).gvalue.(*goItemModel)
 	indexMi := mkModelIndex(index, im.common.engine)
 
 	v := im.impl.Data(indexMi, Role(role))
@@ -209,8 +212,8 @@ func implData(qim uintptr, index uintptr, role int, ret *C.DataValue) {
 }
 
 //export implIndex
-func implIndex(qim uintptr, row int, column int, parent uintptr) uintptr {
-	im := (*goItemModel)(unsafe.Pointer(qim))
+func implIndex(qim C.GoValueRef, row int, column int, parent uintptr) uintptr {
+	im := foldFromRef(qim).gvalue.(*goItemModel)
 	parentMi := mkModelIndex(parent, im.common.engine)
 
 	ret := im.impl.Index(row, column, parentMi)
@@ -222,8 +225,8 @@ func implIndex(qim uintptr, row int, column int, parent uintptr) uintptr {
 }
 
 //export implParent
-func implParent(qim uintptr, index uintptr) uintptr {
-	im := (*goItemModel)(unsafe.Pointer(qim))
+func implParent(qim C.GoValueRef, index uintptr) uintptr {
+	im := foldFromRef(qim).gvalue.(*goItemModel)
 	indexMi := mkModelIndex(index, im.common.engine)
 	parentMi := im.impl.Parent(indexMi)
 	if parentMi != nil {
@@ -234,8 +237,8 @@ func implParent(qim uintptr, index uintptr) uintptr {
 }
 
 //export implRowCount
-func implRowCount(qim uintptr, parent uintptr) int {
-	im := (*goItemModel)(unsafe.Pointer(qim))
+func implRowCount(qim C.GoValueRef, parent uintptr) int {
+	im := foldFromRef(qim).gvalue.(*goItemModel)
 	parentMi := mkModelIndex(parent, im.common.engine)
 
 	return im.impl.RowCount(parentMi)
@@ -243,16 +246,16 @@ func implRowCount(qim uintptr, parent uintptr) int {
 
 // Required for editing
 //export implFlags
-func implFlags(qim uintptr, index uintptr) ItemFlags {
-	im := (*goItemModel)(unsafe.Pointer(qim))
+func implFlags(qim C.GoValueRef, index uintptr) ItemFlags {
+	im := foldFromRef(qim).gvalue.(*goItemModel)
 	indexMi := mkModelIndex(index, im.common.engine)
 
 	return im.impl.Flags(indexMi)
 }
 
 //export implSetData
-func implSetData(qim uintptr, index uintptr, dv *C.DataValue, role int) bool {
-	im := (*goItemModel)(unsafe.Pointer(qim))
+func implSetData(qim C.GoValueRef, index uintptr, dv *C.DataValue, role int) bool {
+	im := foldFromRef(qim).gvalue.(*goItemModel)
 	indexMi := mkModelIndex(index, im.common.engine)
 
 	value := unpackDataValue(dv, im.common.engine)

--- a/goitemmodel.go
+++ b/goitemmodel.go
@@ -48,7 +48,7 @@ type goItemModel struct {
 	impl   ItemModelImpl
 }
 
-func (q *goItemModel) internal_ItemModel() *goItemModel { return q }
+func (qim *goItemModel) internal_ItemModel() *goItemModel { return qim }
 
 func NewItemModel(engine *Engine, parent Object, impl ItemModelImpl) (ItemModel, ItemModelInternal) {
 	im := mkItemModel()
@@ -212,7 +212,7 @@ func implData(qim C.GoValueRef, index uintptr, role int, ret *C.DataValue) {
 }
 
 //export implIndex
-func implIndex(qim C.GoValueRef, row int, column int, parent uintptr) uintptr {
+func implIndex(qim C.GoValueRef, row int, column int, parent uintptr) unsafe.Pointer {
 	im := foldFromRef(qim).gvalue.(*goItemModel)
 	parentMi := mkModelIndex(parent, im.common.engine)
 
@@ -221,11 +221,11 @@ func implIndex(qim C.GoValueRef, row int, column int, parent uintptr) uintptr {
 		return ret.(*qModelIndex).ptr
 	}
 
-	return 0
+	return nil
 }
 
 //export implParent
-func implParent(qim C.GoValueRef, index uintptr) uintptr {
+func implParent(qim C.GoValueRef, index uintptr) unsafe.Pointer {
 	im := foldFromRef(qim).gvalue.(*goItemModel)
 	indexMi := mkModelIndex(index, im.common.engine)
 	parentMi := im.impl.Parent(indexMi)
@@ -233,7 +233,7 @@ func implParent(qim C.GoValueRef, index uintptr) uintptr {
 		return parentMi.(*qModelIndex).ptr
 	}
 
-	return 0
+	return nil
 }
 
 //export implRowCount

--- a/gomodelindex.go
+++ b/gomodelindex.go
@@ -12,7 +12,7 @@ import "C"
 import "unsafe"
 
 type qModelIndex struct {
-	ptr    uintptr
+	ptr    unsafe.Pointer
 	engine *Engine
 }
 
@@ -21,7 +21,7 @@ func mkModelIndex(ptr uintptr, engine *Engine) ModelIndex {
 		return nil
 	}
 	return &qModelIndex{
-		ptr:    ptr,
+		ptr:    unsafe.Pointer(ptr),
 		engine: engine,
 	}
 }
@@ -45,50 +45,50 @@ type ModelIndex interface {
 func (i *qModelIndex) internal_ModelIndex() {}
 
 func (i *qModelIndex) Child(row, col int) ModelIndex {
-	return mkModelIndex(uintptr(C.modelIndexChild(unsafe.Pointer(i.ptr), C.int(row), C.int(col))), i.engine)
+	return mkModelIndex(uintptr(C.modelIndexChild(i.ptr, C.int(row), C.int(col))), i.engine)
 }
 
 func (i *qModelIndex) Sibling(row, col int) ModelIndex {
-	return mkModelIndex(uintptr(C.modelIndexSibling(unsafe.Pointer(i.ptr), C.int(row), C.int(col))), i.engine)
+	return mkModelIndex(uintptr(C.modelIndexSibling(i.ptr, C.int(row), C.int(col))), i.engine)
 }
 
 func (i *qModelIndex) Column() int {
-	return int(C.modelIndexColumn(unsafe.Pointer(i.ptr)))
+	return int(C.modelIndexColumn(i.ptr))
 }
 
 func (i *qModelIndex) Row() int {
-	return int(C.modelIndexRow(unsafe.Pointer(i.ptr)))
+	return int(C.modelIndexRow(i.ptr))
 }
 
 func (i *qModelIndex) Data(role Role) interface{} {
 	var dvalue C.DataValue
-	C.modelIndexData(unsafe.Pointer(i.ptr), C.int(role), &dvalue)
+	C.modelIndexData(i.ptr, C.int(role), &dvalue)
 	return unpackDataValue(&dvalue, i.engine)
 }
 
 func (i *qModelIndex) Flags() ItemFlags {
-	return ItemFlags(C.modelIndexFlags(unsafe.Pointer(i.ptr)))
+	return ItemFlags(C.modelIndexFlags(i.ptr))
 }
 
 func (i *qModelIndex) InternalId() uintptr {
-	return uintptr(C.modelIndexInternalId(unsafe.Pointer(i.ptr)))
+	return uintptr(C.modelIndexInternalId(i.ptr))
 }
 
 func (i *qModelIndex) InternalPointer() uintptr {
-	return uintptr(C.modelIndexInternalPointer(unsafe.Pointer(i.ptr)))
+	return uintptr(C.modelIndexInternalPointer(i.ptr))
 }
 
 func (i *qModelIndex) IsValid() bool {
-	if i == nil || i.ptr == 0 {
+	if i == nil || uintptr(i.ptr) == 0 {
 		return false
 	}
-	return bool(C.modelIndexIsValid(unsafe.Pointer(i.ptr)))
+	return bool(C.modelIndexIsValid(i.ptr))
 }
 
 func (i *qModelIndex) Model() ItemModel {
-	return itemModelFromCPP(uintptr(C.modelIndexModel(unsafe.Pointer(i.ptr))), i.engine)
+	return itemModelFromCPP(uintptr(C.modelIndexModel(i.ptr)), i.engine)
 }
 
 func (i *qModelIndex) Parent() ModelIndex {
-	return mkModelIndex(uintptr(C.modelIndexParent(unsafe.Pointer(i.ptr))), i.engine)
+	return mkModelIndex(uintptr(C.modelIndexParent(i.ptr)), i.engine)
 }

--- a/gomodelindex.go
+++ b/gomodelindex.go
@@ -79,7 +79,7 @@ func (i *qModelIndex) InternalPointer() uintptr {
 }
 
 func (i *qModelIndex) IsValid() bool {
-	if i == nil || uintptr(i.ptr) == 0 {
+	if i == nil || i.ptr == nil {
 		return false
 	}
 	return bool(C.modelIndexIsValid(i.ptr))

--- a/qmlcommon.go
+++ b/qmlcommon.go
@@ -472,11 +472,13 @@ func hookSignalDisconnect(funcref C.GoValueRef) {
 //export hookSignalCall
 func hookSignalCall(enginep unsafe.Pointer, funcref C.GoValueRef, args *C.DataValue) {
 	engine := engines[enginep]
-	if engine == nil {
-		panic("signal called after engine was destroyed")
-	}
 	fold := foldFromRef(funcref)
 	funcv := reflect.ValueOf(*fold.gvalue.(*interface{}))
+
+	if engine == nil {
+		fmt.Println(fmt.Sprintf("signal called after engine was destroyed: %v %v", fold, runtime.FuncForPC(funcv.Pointer()).Name()))
+	}
+
 	funct := funcv.Type()
 	numIn := funct.NumIn()
 	var params [C.MaxParams]reflect.Value

--- a/qmlcommon.go
+++ b/qmlcommon.go
@@ -443,8 +443,6 @@ func (obj *Common) On(signal string, function interface{}) {
 		if cerr == nil {
 			connectedFunction[&function] = true
 			stats.connectionsAlive(+1)
-		} else {
-
 		}
 	})
 	cmust(cerr)

--- a/qmlengine.go
+++ b/qmlengine.go
@@ -47,6 +47,7 @@ func NewEngine() *Engine {
 		engine.imageProviders = make(map[string]*func(imageId string, width, height int) image.Image)
 		engines[engine.addr] = engine
 		stats.enginesAlive(+1)
+		engine.On("destroyed", engine.onDestroyed)
 	})
 	return engine
 }
@@ -67,16 +68,20 @@ func (e *Engine) Destroy() {
 			if !e.destroyed {
 				e.destroyed = true
 				C.delObjectLater(e.addr)
-				if len(e.values) == 0 {
-					delete(engines, e.addr)
-				} else {
-					// The engine reference keeps those values alive.
-					// The last value destroyed will clear it.
-				}
-				stats.enginesAlive(-1)
 			}
 		})
 	}
+}
+
+func (e *Engine) onDestroyed() {
+	if len(e.values) == 0 {
+		delete(engines, e.addr)
+	} else {
+		// The engine reference keeps those values alive.
+		// The last value destroyed will clear it.
+	}
+	stats.enginesAlive(-1)
+
 }
 
 // Load loads a new component with the provided location and with the


### PR DESCRIPTION
Store all the folds in a map and pass an atomically incremented key instead of a Go pointer. This works well, but currently, nothing can ever be garbage collected once it passes through the map. This is obviously a problem and is going to need to be fixed soon. Ideas?
